### PR TITLE
Add per-directory indexing support

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -637,6 +637,7 @@ export const DEFAULT_SETTINGS: CopilotSettings = {
   chatNoteContextPath: "",
   chatNoteContextTags: [],
   enableIndexSync: true,
+  activeIndexDir: "",
   debug: false,
   enableEncryption: false,
   maxSourceChunks: 3,

--- a/src/search/dbOperations.ts
+++ b/src/search/dbOperations.ts
@@ -229,14 +229,15 @@ export class DBOperations {
   public async getDbPath(): Promise<string> {
     const vaultRoot = this.app.vault.getRoot().path;
     let baseDir: string;
+    const indexDir = getSettings().activeIndexDir || "";
 
     if (getSettings().enableIndexSync) {
-      baseDir = this.app.vault.configDir;
+      baseDir = `${this.app.vault.configDir}/${indexDir}/.copilot-index`.replace(/\/+/g, "/");
     } else {
       // If vaultRoot is just "/", treat it as empty
       const effectiveRoot = vaultRoot === "/" ? "" : vaultRoot;
       const prefix = effectiveRoot === "" || effectiveRoot.startsWith("/") ? "" : "/";
-      baseDir = `${prefix}${effectiveRoot}/.copilot-index`;
+      baseDir = `${prefix}${effectiveRoot}/${indexDir}/.copilot-index`.replace(/\/+/g, "/");
 
       // Ensure the directory exists
       if (!(await this.app.vault.adapter.exists(baseDir))) {

--- a/src/search/indexOperations.ts
+++ b/src/search/indexOperations.ts
@@ -273,7 +273,10 @@ export class IndexOperations {
 
   private async getFilesToIndex(overwrite?: boolean): Promise<TFile[]> {
     const { inclusions, exclusions } = getMatchingPatterns();
-    const allMarkdownFiles = this.app.vault.getMarkdownFiles();
+    const indexDir = getSettings().activeIndexDir;
+    const allMarkdownFiles = this.app.vault
+      .getMarkdownFiles()
+      .filter((file) => !indexDir || file.path.startsWith(indexDir));
 
     // If overwrite is true, return all markdown files that match current filters
     if (overwrite) {

--- a/src/search/vectorStoreManager.ts
+++ b/src/search/vectorStoreManager.ts
@@ -42,8 +42,11 @@ export default class VectorStoreManager {
       const prevSettings = this.lastKnownSettings;
       this.lastKnownSettings = { ...settings };
 
-      // Handle path changes (enableIndexSync)
-      if (settings.enableIndexSync !== prevSettings?.enableIndexSync) {
+      // Handle path changes (enableIndexSync or activeIndexDir)
+      if (
+        settings.enableIndexSync !== prevSettings?.enableIndexSync ||
+        settings.activeIndexDir !== prevSettings?.activeIndexDir
+      ) {
         const newPath = await this.dbOps.getDbPath();
         const oldPath = this.dbOps.getCurrentDbPath();
 

--- a/src/settings/model.ts
+++ b/src/settings/model.ts
@@ -77,6 +77,8 @@ export interface CopilotSettings {
   chatNoteContextPath: string;
   chatNoteContextTags: string[];
   enableIndexSync: boolean;
+  /** Directory relative to vault root for storing Copilot index */
+  activeIndexDir: string;
   debug: boolean;
   enableEncryption: boolean;
   maxSourceChunks: number;
@@ -225,6 +227,10 @@ export function sanitizeSettings(settings: CopilotSettings): CopilotSettings {
   // Ensure includeActiveNoteAsContext has a default value
   if (typeof sanitizedSettings.includeActiveNoteAsContext !== "boolean") {
     sanitizedSettings.includeActiveNoteAsContext = DEFAULT_SETTINGS.includeActiveNoteAsContext;
+  }
+
+  if (!sanitizedSettings.activeIndexDir && sanitizedSettings.activeIndexDir !== "") {
+    sanitizedSettings.activeIndexDir = DEFAULT_SETTINGS.activeIndexDir;
   }
 
   // Ensure passMarkdownImages has a default value

--- a/src/settings/v2/components/QASettings.tsx
+++ b/src/settings/v2/components/QASettings.tsx
@@ -223,6 +223,15 @@ export const QASettings: React.FC = () => {
             onCheckedChange={(checked) => updateSetting("enableIndexSync", checked)}
           />
 
+          {/* Index directory */}
+          <SettingItem
+            type="text"
+            title="Index directory"
+            description="Relative path of directory to index. Leave empty to index entire vault."
+            value={settings.activeIndexDir}
+            onChange={(value) => updateSetting("activeIndexDir", value)}
+          />
+
           {/* Disable index loading on mobile */}
           <SettingItem
             type="switch"


### PR DESCRIPTION
## Summary
- introduce `activeIndexDir` setting for vault indexing
- adjust DB path calculation to use the chosen directory
- reinitialize DB when the directory changes
- limit indexer to files within the active directory
- expose setting in QA options

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68544ed3271c832b962959bc01a58fa4